### PR TITLE
Added brand support to product.js

### DIFF
--- a/backend/files/app/code/local/Crossroads/API/controllers/ProductController.php
+++ b/backend/files/app/code/local/Crossroads/API/controllers/ProductController.php
@@ -59,6 +59,9 @@ class Crossroads_API_ProductController extends Crossroads_API_Controller_Super
       $product->image = (string)$this->imageHelper->init($product, 'image')->resize(IMAGE_SIZE);
       $product->options = $this->prepareOptions($product);
       $product->media_gallery = $this->prepareMediaGallery($product);
+      $manufacturerKey = array( 'name', 'id' );
+      $manufacturerValue = array( $product->getAttributeText('manufacturer'), $product->manufacturer );
+      $product->manufacturer = array_combine( $manufacturerKey, $manufacturerValue ); // Make manufacturer return text instead of id
 
       // finalPrice is too slow. Maybe we need to index it.
       // $product->finalPrice = $product->getFinalPrice();

--- a/src/containers/Product/Product.js
+++ b/src/containers/Product/Product.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { autobind } from 'core-decorators';
 
-import { ProductOptions, QuantityPicker, Price } from '../../components';
+import { ProductOptions, QuantityPicker, Price, Brand } from '../../components';
 import { Media } from '../';
 
 import { load } from '../../redux/modules/product';
@@ -76,6 +76,7 @@ export default class extends Component {
       <div>
         <div className={style.left}>
           <h1>{product.data.name}</h1>
+          <h2>{product.data.manufacturer.name}</h2>
           <br />
           <p className={style.description}>{product.data.description}</p>
           <ProductOptions options={product.data.options} />

--- a/src/containers/Product/Product.js
+++ b/src/containers/Product/Product.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { autobind } from 'core-decorators';
 
-import { ProductOptions, QuantityPicker, Price, Brand } from '../../components';
+import { ProductOptions, QuantityPicker, Price } from '../../components';
 import { Media } from '../';
 
 import { load } from '../../redux/modules/product';


### PR DESCRIPTION
Not sure if this is necessary, but I changed the API controller to return both the ID and name of the brand. This way, I could just use `product.data.manufacturer.name` in `Product.js` in order to display the brand name. No product in the test data has an assigned Manufacturer, so you won't see it until we fix better test data.
